### PR TITLE
Update 05_call_clones_together.R

### DIFF
--- a/figure_paired_cd34_pbmc/code/05_call_clones_together.R
+++ b/figure_paired_cd34_pbmc/code/05_call_clones_together.R
@@ -31,6 +31,7 @@ table(cluster_name)
 
 # Import meta data
 sdf <- readRDS("../output/PBMCatac_SignacSeurat_labelTransfer.rds")
+sdf <- sdf[colnames(afin1),] #make sure the order of cells is the same
 sdf$mito_cluster <- cluster_name[1:dim(afin1)[2]]
 
 load("../output/CD34_umap_embedding_granja.rda")


### PR DESCRIPTION

[bias_X2_comparison.pdf](https://github.com/caleblareau/mtscATACpaper_reproducibility/files/12040123/bias_X2_comparison.pdf)
By adding this line, the order of cells in the sdf object and afin1 matrix will be the same, assigning the correct allele frequencies to the cells. This affects the results of the chi-squared test in 08_evaluate_global_bias.R and the UMAP figures in 09_viz_anecdotes.R, and possibly the stacked barplot in 06_stacked_bar_pbmc.R.